### PR TITLE
encode card in key order; required for output string consistency

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -3,6 +3,7 @@ package vcard
 import (
 	"errors"
 	"io"
+	"sort"
 	"strings"
 )
 
@@ -31,7 +32,13 @@ func (enc *Encoder) Encode(c Card) error {
 		return err
 	}
 
-	for k, fields := range c {
+	var keys []string
+	for k := range c {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		fields := c[k]
 		if strings.EqualFold(k, FieldVersion) {
 			continue
 		}

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -12,6 +12,11 @@ func TestEncoder(t *testing.T) {
 		t.Fatal("Expected no error when formatting card, got:", err)
 	}
 
+	expected := "BEGIN:VCARD\r\nVERSION:4.0\r\nCLIENTPIDMAP:1;urn:uuid:53e374d9-337e-4727-8803-a1e9c14e0556\r\nEMAIL;PID=1.1:jdoe@example.com\r\nFN;PID=1.1:J. Doe\r\nN:Doe;J.;;;\r\nUID:urn:uuid:4fbe8971-0bc3-424c-9c26-36c3e1eff6b1\r\nEND:VCARD\r\n"
+	if b.String() != expected {
+		t.Errorf("Excpected vcard to be %q, but got %q", expected, b.String())
+	}
+
 	card, err := NewDecoder(&b).Decode()
 	if err != nil {
 		t.Fatal("Expected no error when parsing formatted card, got:", err)


### PR DESCRIPTION
For testability