### PR TITLE
Encode: deterministic output

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -62,8 +62,13 @@ func formatLine(key string, field *Field) string {
 	}
 	s += key
 
-	for pk, pvs := range field.Params {
-		for _, pv := range pvs {
+	var keys []string
+	for k := range field.Params {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, pk := range keys {
+		for _, pv := range field.Params[pk] {
 			s += ";" + formatParam(pk, pv)
 		}
 	}


### PR DESCRIPTION
Likely an omission of #12 b41a0079f90ba4cb0691d3b33c6d2be001438a84 which sorted the property names, but not the field parameter names.

https://github.com/emersion/go-vcard/blob/8fda7d206ec99614d3e5fe529b060a2ed84010ff/encoder.go#L39

---

## Why is a deterministic output desirable?

vCard is the standard used by CardDAV servers. 

According to the standard [rfc6352#section-3](https://datatracker.ietf.org/doc/html/rfc6352#section-3):
> To advertise support for CardDAV, a server:
> - MUST support ETags [[RFC2616](https://datatracker.ietf.org/doc/html/rfc2616)] with additional requirements specified in [Section 6.3.2.3](https://datatracker.ietf.org/doc/html/rfc6352#section-6.3.2.3) of this document;

And later in [section-6.3.2.3](https://datatracker.ietf.org/doc/html/rfc6352#section-6.3.2.3):
> The DAV:getetag property MUST be defined and set to a strong entity tag on all address object resources.

This means that when the content of the card did not change, the HTTP response must be byte-for-byte identical to a previous response with the same ETag.

This is currently not the case when using `Encode`.

An alternative solution would be to re-implement `Encode` to be stable on the CardDAV server side, however I believe that having the stability here would be more helpful.